### PR TITLE
Add regex to remove comments from xml string

### DIFF
--- a/app/src/dataHandler/baseData.service.js
+++ b/app/src/dataHandler/baseData.service.js
@@ -105,6 +105,7 @@ angular.module('evtviewer.dataHandler')
      */
     var addXMLDocument = function(doc) {
         var deferred = $q.defer();
+        doc = doc.replace(/<!--.*-->/gm, '');
         docElements = xmlParser.parse(doc);
         if (docElements.documentElement.nodeName === 'TEI') {
             state.XMLStrings.push(doc);


### PR DESCRIPTION
Pages split and XML re-balance is performed with regex on XML DOM string, thus comments are a problem. Since they're no used in the visualization, it's ok to remove them.

Closes #51