### PR TITLE
changed tileLayer for better compatibility

### DIFF
--- a/app/src/namedEntity/namedEntity.provider.js
+++ b/app/src/namedEntity/namedEntity.provider.js
@@ -390,7 +390,7 @@ angular.module('evtviewer.namedEntity')
                     draggable: false
                 };
                 var lfDefaults = {
-                    tileLayer: "http://{s}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png",
+                    tileLayer: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
                     tileLayerOptions: {
                         opacity: 0.9,
                         detectRetina: true,


### PR DESCRIPTION
The previous map sometimes is not visible (probably due to errors in the tiling serve) and has a visible watermark.
The one proposed has a free licence even for commercial use, and a very high annual rate limit (over 1 million tiles requested per day). Please check https://www.esri.com/news/arcnews/spring11articles/new-arcgis-online-content.html for licence usage and how credits must be attributed.

