### PR TITLE
Fix Virtual Keyboard Error

### DIFF
--- a/app/src/search/virtualKeyboard.directive.js
+++ b/app/src/search/virtualKeyboard.directive.js
@@ -2,7 +2,7 @@ angular.module('evtviewer.search')
    .directive('evtVirtualKeyboard', ['evtVirtualKeyboard', 'parsedData',  function(evtVirtualKeyboard, parsedData) {
       return {
          restrict: 'E',
-         tempalte: require('./virtualKeyboard.directive.tmpl.html'),
+         template: require('./virtualKeyboard.directive.tmpl.html'),
          replace: true,
          link: function(scope) {
             var glyphs = parsedData.getGlyphs();


### PR DESCRIPTION
Changed from "tempalte" to "template", now the directive's template is loaded correctly.